### PR TITLE
Check for output after `pyodide.runPython()`

### DIFF
--- a/static/js/workers/py.worker.js
+++ b/static/js/workers/py.worker.js
@@ -229,7 +229,13 @@ class API extends BaseAPI {
     globals.set('__name__', '__main__');
 
     try {
-      this.pyodide.runPython(code.join('\n'), { globals, locals: globals });
+      // Most of the output will end up in the raw stdout handler defined
+      // earlier, but some output will still end up in the console, which
+      // generally happens solely for config buttons.
+      const result = this.pyodide.runPython(code.join('\n'), { globals, locals: globals });
+      if (result) {
+        this.hostWrite(result);
+      }
     } catch (err) {
       return this.formatErrorMsg(err.message, activeTabName);
     } finally {


### PR DESCRIPTION
Most about is redirected to the raw stdout callback, but this is not the case for config buttons (sometimes). Simply check if the returned result of `pyodide.runPython()` has a value and if so, print it to the terminal.