### PR TITLE
Force reload file content when opening

### DIFF
--- a/static/js/layout/editor.component.js
+++ b/static/js/layout/editor.component.js
@@ -216,7 +216,6 @@ class EditorComponent {
    */
   onEditorFocus = () => {
     this.setActiveEditor();
-    this.reloadFileContent();
 
     // Spawn a new worker if necessary.
     createLangWorkerApi(this.proglang);
@@ -249,14 +248,21 @@ class EditorComponent {
       this.setActiveEditor();
     }
 
+    this.reloadFileContent(true);
+
     // Spawn a new worker if necessary.
     if (this.ready) {
       createLangWorkerApi(this.proglang);
     }
   }
 
-  reloadFileContent = () => {
-    if (window._blockLFSPolling) return;
+  /**
+   * Reload the file content either from VFS or LFS.
+   *
+   * @param {boolen} [force] - True to force reload the file content from LFS.
+   */
+  reloadFileContent = (force = false) => {
+    if (window._blockLFSPolling && !force) return;
 
     const file = VFS.findFileById(this.container.getState().fileId);
     if (file) {

--- a/static/js/lfs.js
+++ b/static/js/lfs.js
@@ -214,10 +214,11 @@ class LocalFileSystem {
    */
   async getFileContent(id) {
     try {
-      const fileHandle = await this.getFileHandle(VFS.getAbsoluteFilePath(id));
+      const path = VFS.getAbsoluteFilePath(id)
+      const fileHandle = await this.getFileHandle(path);
       const file = await fileHandle.handle.getFile();
       const content = await file.text();
-      return content;
+      return content.trim();
     } catch (err) {
       console.error('Failed to get file content:', err);
     }
@@ -538,7 +539,7 @@ class LocalFileSystem {
       }
 
       const writable = await fileHandle.createWritable();
-      await writable.write(content);
+      await writable.write(content.trim() + '\n');
       await writable.close();
     } finally {
       this.busy = false;


### PR DESCRIPTION
This PR adds the following changes for the IDE:
- Always force load the file content when the user opens it ([TODO#8012721897](https://3.basecamp.com/3088496/buckets/32433293/todos/8012721897))
- Make sure to visually not show the trailing newline character, while still writing it when writing the file contents