### PR TITLE
fix: remove drag workaround, mouseup problem

### DIFF
--- a/static/js/helpers/editor-component.js
+++ b/static/js/helpers/editor-component.js
@@ -114,7 +114,8 @@ Terra.f.openFile = (id, filename) => {
       });
 
       if (removeFirstTab) {
-        Terra.f.getAllEditorTabs()[1].instance.fakeOnContainerOpenEvent = true;
+        Terra.f.getAllEditorTabs()[0].instance.fakeOnContainerOpenEvent = true;
+        Terra.f.getAllEditorTabs()[0].instance.fakeOnEditorFocusEvent = true;
         currentTab.parent.removeChild(tabs[0]);
       }
     }

--- a/static/js/layout/editor.component.js
+++ b/static/js/layout/editor.component.js
@@ -490,7 +490,7 @@ class EditorComponent {
       }
     });
 
-    this.editor.session.on('change', () => {
+    this.editor.on('change', () => {
       this.onEditorChange();
       if (Terra.c.IS_IDE) {
         Terra.pluginManager.triggerEvent('onEditorChange', this);

--- a/static/js/layout/editor.component.js
+++ b/static/js/layout/editor.component.js
@@ -31,6 +31,7 @@ class EditorComponent {
    * that the user did was open file.
    */
   fakeOnContainerOpenEvent = false;
+  fakeOnEditorFocusEvent = false;
 
   constructor(container, state) {
     this.container = container;
@@ -205,6 +206,11 @@ class EditorComponent {
    * Callback when the user's cursor is focused on the editor.
    */
   onEditorFocus = () => {
+    if (this.fakeOnEditorFocusEvent) {
+      this.fakeOnEditorFocusEvent = false;
+      return;
+    }
+
     this.setActiveEditor();
 
     // Spawn a new worker if necessary.
@@ -484,12 +490,7 @@ class EditorComponent {
       }
     });
 
-    this.editor.on('change', () => {
-      // GoldenLayout removes and re-inserts texts when dragging tabs, which
-      // in the end didn't change any of the contents, so we should ignore
-      // the change event in this case.
-      if (Terra.v.isDraggingTab) return;
-
+    this.editor.session.on('change', () => {
       this.onEditorChange();
       if (Terra.c.IS_IDE) {
         Terra.pluginManager.triggerEvent('onEditorChange', this);
@@ -518,8 +519,6 @@ class EditorComponent {
     });
 
     this.container.on('show', () => {
-      if (Terra.v.isDraggingTab) return;
-
       this.onContainerOpen();
       if (Terra.c.IS_IDE) {
         Terra.pluginManager.triggerEvent('onEditorContainerOpen', this);

--- a/static/js/layout/layout.js
+++ b/static/js/layout/layout.js
@@ -33,20 +33,6 @@ class Layout extends GoldenLayout {
 
     this.on('stateChanged', () => this.onStateChanged());
 
-    this.on('tabCreated', (tab) => {
-      // Add a custom 'dragStart' event, since GoldenLayout doesn't have this.
-      const $tab = $(tab.element);
-      const fileId = tab.contentItem.container.getState().fileId;
-
-      $tab.on('mousedown', (event) => {
-        Terra.v.isDraggingTab = true;
-      });
-
-      $(document).off('mouseup').on('mouseup', (event) => {
-        Terra.v.isDraggingTab = false;
-      });
-    });
-
     this.on('stackCreated', (stack) => {
       if (!this.initialised) {
         this.initialised = true;


### PR DESCRIPTION
Context:

using `$(document).off('mouseup')` was a problem: the file context menu stopped working, e.g. downloading (test this by opening a file for editing first, then try to download it)

Changes:
1. removed drag workaround completely (see 2)
2. ~~put the change event listener on the session object `this.editor.session.on('change', ...)` so the workaround isn't needed anymore~~
3. add `fakeOnEditorFocusEvent` for `onEditorFocus` because this was making the language worker flip on-off-on

Number 3 doesn't reaaaally have anything to do with the other things.