### PR TITLE
fix: reinstate ctrl-enter handler for run

### DIFF
--- a/static/js/layout/editor.component.js
+++ b/static/js/layout/editor.component.js
@@ -81,6 +81,10 @@ class EditorComponent {
    * Bind all custom editor commands.
    */
   bindEditorCommands = () => {
+    // remove default sublime Ctrl+Enter command
+    this.editor.commands.removeCommand('addLineAfter');
+
+    // add custom commands
     this.editor.commands.addCommand({
       name: 'run',
       bindKey: { win: 'Ctrl+Enter', mac: 'Command+Enter' },


### PR DESCRIPTION
ctrl-enter for run did not work anymore (likely after upgrading Ace)
-> now removing the previous bind before adding ours