### PR TITLE
fix regex: https should be optional

### DIFF
--- a/static/js/helpers/shared.js
+++ b/static/js/helpers/shared.js
@@ -110,7 +110,7 @@ export function objectHasKeys(obj, keys) {
  * @returns {boolean} True when the url is valid.
  */
 export function isValidUrl(url) {
-  return /^https:?\/\//g.test(url);
+  return /^https?:\/\//g.test(url);
 }
 
 /**


### PR DESCRIPTION
Currently, the `:` is optional when checking the valid URL. I think this was a mistake? In any case I would like the `s` to be optional for my local testing.