### PR TITLE
fix: call `Terra.app.closeFile()` correctly

### DIFF
--- a/static/js/layout/layout.ide.js
+++ b/static/js/layout/layout.ide.js
@@ -77,7 +77,7 @@ export default class IDELayout extends Layout {
       {
         name: 'closeFile',
         bindKey: 'Ctrl+W',
-        exec: () => this.closeFile(),
+        exec: () => Terra.app.closeFile(),
       },
       {
         name: 'createNewFileTreeFile',


### PR DESCRIPTION
Right now files can't be closed anymore because I forgot to change this reference after the last PR where the `Layout.closeFile` moved to `App.closeFile`.